### PR TITLE
change executionType from BATCH to HPC for tapis v2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Tapis V2 Apps Templates
 
 Project types:
 
-    * Scheduling: CLI vs Batch
+    * Scheduling: CLI vs Batch (HPC)
     * Parallelism: Serial vs Parallel
     * Runtime: Container vs Native
 

--- a/default/{{ cookiecutter.project_slug }}/app.json
+++ b/default/{{ cookiecutter.project_slug }}/app.json
@@ -2,7 +2,7 @@
   "checkpointable": false,
   "name": "{{ app.name }}",
   "executionSystem": "{{ app.execution_system }}",
-  "executionType": "BATCH",
+  "executionType": "HPC",
   "deploymentPath": "{{ username }}/apps/{{ app.name }}-{{ app.version }}",
   "deploymentSystem": "{{ app.deployment_system }}",
   "helpURI": "",


### PR DESCRIPTION
Tapis v2 executionType must be one of:

`ATMOSPHERE,HPC,CONDOR,CLI`

Changing "BATCH" to "HPC" here will avoid errors if users are using this template to create apps in v2.